### PR TITLE
New custom attributes for user account and geolocation

### DIFF
--- a/2.0/custom-user-account.md
+++ b/2.0/custom-user-account.md
@@ -1,0 +1,30 @@
+## user-account object with custom attributes
+
+Specifies custom atributes for the [`user-account`](https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html#_azo70vgj1vm2) object to describe commonly used descriptors for a user account.
+
+| property name | type | description |
+|--|--|--|
+| x_domain | `string` | Specifies the internal product name of the file, provided at compile-time. e.g., Microsoft® Windows® Operating System |
+| x_hash | `string` | Specifies the unique user hash to correlate information for a user in anonymized form. It is useful if user.id or user.name contain confidential information and cannot be used. |
+| x_group | `dictionary` | Specifies the groups that are relevant to the event. Each dictionary key SHOULD come from the user group vocabulary.|
+
+### User group vocabulary
+| value | type | description |
+|--|--|--|
+| domain | `string` | Specifies the name of the directory the group is a member of. e.g., an LDAP or Active Directory domain name|
+| id | `integer` | Specifies the unique identifier for the group on the system/platform |
+| name | `string` | Specifies the name of the group |
+
+Example:
+
+    {
+        "0": {
+            "type": "user-account",
+            "x_domain": "NT AUTHORITY",
+            "user_id": "SYSTEM",
+            "account_login": "SYSTEM",
+            "x_group.id": "515",
+            "x_group.name": "Domain local group",
+            "x_group.domain": "internal.company.com"
+        }
+    }

--- a/2.0/x-ibm-finding.md
+++ b/2.0/x-ibm-finding.md
@@ -17,8 +17,8 @@ Where possible, references are made to existing STIX objects (ie. ip addresses, 
 | dst_os_ref | `object-ref` | Specifies the destination operating system of the finding, as a reference to the Cyber-observable Object. The object referenced must be of type `software`. |
 | src_application_ref | `object-ref` | Specifies the source application of the finding, as a reference to the Cyber-observable Object. The object referenced must be of type `software`. |
 | dst_application_ref | `object-ref` | Specifies the destination application of the finding, as a reference to the Cyber-observable Object. The object referenced must be of type `software`. |
-| src_geolocation | `string` | Specifies the source geographic location of the finding. |
-| dst_geolocation | `string` | Specifies the destination geographic location of the finding. |
+| src_geo_ref | `object-ref` | Specifies the source geographic location of the finding, as a reference to the Cyber-observable Object. The object referenced must be of type `x-oca-geo`.|
+| dst_geo_ref | `object-ref` | Specifies the destination geographic location of the finding, as a reference to the Cyber-observable Object. The object referenced must be of type `x-oca-geo`.|
 | src_device | `string` | Specifies the source device of the finding. (ie. database, browser) |
 | dst_device | `string` | Specifies the destination device of the finding. (ie. database, browser) |
 | src_application_user_ref | `object-ref` | Specifies the source application user of the finding, as a reference to the Cyber-observable Object. The object referenced must be of type `user-account`. |
@@ -79,7 +79,7 @@ Where possible, references are made to existing STIX objects (ie. ip addresses, 
           "dst_ip_ref": "1",
           "src_application_user_ref": "2",
           "src_application_ref": "3",
-          "src_geolocation": "USA",
+          "src_geo_ref": "8",
           "src_device": "Chrome",
           "ttp_tagging_refs": [5], 
           "ioc_refs": ["6","7"]
@@ -115,6 +115,10 @@ Where possible, references are made to existing STIX objects (ie. ip addresses, 
         "7": {
                 "type": "url",
                 "value": "http://maliciousmalware.bad"
+        },
+        "8": {
+                "type": "x-oca-geo",
+                "country_iso_code": "US"
         }
     }
 }

--- a/2.0/x-ibm-finding.md
+++ b/2.0/x-ibm-finding.md
@@ -17,8 +17,8 @@ Where possible, references are made to existing STIX objects (ie. ip addresses, 
 | dst_os_ref | `object-ref` | Specifies the destination operating system of the finding, as a reference to the Cyber-observable Object. The object referenced must be of type `software`. |
 | src_application_ref | `object-ref` | Specifies the source application of the finding, as a reference to the Cyber-observable Object. The object referenced must be of type `software`. |
 | dst_application_ref | `object-ref` | Specifies the destination application of the finding, as a reference to the Cyber-observable Object. The object referenced must be of type `software`. |
-| src_geo_ref | `object-ref` | Specifies the source geographic location of the finding, as a reference to the Cyber-observable Object. The object referenced must be of type `x-oca-geo`.|
-| dst_geo_ref | `object-ref` | Specifies the destination geographic location of the finding, as a reference to the Cyber-observable Object. The object referenced must be of type `x-oca-geo`.|
+|src_geo_ref | `object-ref` | Specifies the source geographic location of the finding, as a reference to the Cyber-observable Object. The object referenced must be of type `x-oca-geo`.|
+|dst_geo_ref | `object-ref` | Specifies the destination geographic location of the finding, as a reference to the Cyber-observable Object. The object referenced must be of type `x-oca-geo`.|
 | src_device | `string` | Specifies the source device of the finding. (ie. database, browser) |
 | dst_device | `string` | Specifies the destination device of the finding. (ie. database, browser) |
 | src_application_user_ref | `object-ref` | Specifies the source application user of the finding, as a reference to the Cyber-observable Object. The object referenced must be of type `user-account`. |

--- a/2.0/x-oca-asset.md
+++ b/2.0/x-oca-asset.md
@@ -59,6 +59,21 @@ The pod asset extension represents an oc/k8s pod.
 | name | `string` | pod name |
 | ip_refs | `list` of type `object-ref` | references the ip addresses allocated to this pod. must be `ipv4-addr` or `ipv6-addr` |
 
+#### Traffic Dictionary
+
+| value | type | description |
+|--|--|--|
+| zone | `string` | Specifies the network zone of the inbound or outbound traffic.|
+| interface | `dictionary` | Specifies the interface information. Each dictionary key SHOULD come from the Interface vocabulary. |
+
+#### Interface Dictionary
+
+| value | type | description |
+|--|--|--|
+| alias | `string` | Specifies the interface alias as reported by the system. e.g., dmz |
+| id | `string` | Specifies the interface ID. |
+| name | `string` | Specifies the interface name as reported by the system.|
+
 ### Example
 
     {

--- a/2.0/x-oca-asset.md
+++ b/2.0/x-oca-asset.md
@@ -17,6 +17,11 @@ While `x-oca-asset` specifies the host on which the associated event occurred, i
 |mac_refs|`list` of type `object-ref`| references the mac addresses related to this host. must be of type `mac-addr`|
 | os_ref | `object-ref` | Specifies the operating system of the asset, as a reference to the Cyber-observable Object. The object referenced must be of type `software`. |
 | architecture | `string` | Architecture of the asset. |
+| uptime | `string` | Specifies the seconds the asset has been up.|
+| host_type | `string` | Specifies the type of asset. Example, firewall, t2.micro etc.|
+| serial_number | `string` | Specifies the serial number of the asset. |
+| ingress | `dictionary` | Specifies information like interface number and name, vlan, and zone information to classify ingress traffic. Each dictionary key SHOULD come from the Traffic vocabulary.|
+| egress | `dictionary` | Specifies information like interface number and name, vlan, and zone information to classify egress traffic. Each dictionary key SHOULD come from the Traffic vocabulary.|
 
 ### Container Extenstion
 
@@ -70,7 +75,7 @@ The pod asset extension represents an oc/k8s pod.
 
 | value | type | description |
 |--|--|--|
-| alias | `string` | Specifies the interface alias as reported by the system. e.g., dmz |
+| alias | `string` | Specifies the interface alias as reported by the system. |
 | id | `string` | Specifies the interface ID. |
 | name | `string` | Specifies the interface name as reported by the system.|
 
@@ -87,21 +92,30 @@ The pod asset extension represents an oc/k8s pod.
 	        "type": "x-oca-asset",
 	        "ip_refs": ["0", "2"],
 	        "hostname": "example host",
-		"host_id": "123A",
+			"host_id": "123A",
 	        "mac_refs": ["3"],
-		"extensions": {
-		    "x-oca-container-ext": {
-                        "name": "example container",
-                        "id”: “bf032feb4117",
-                        "image_id": "92b1b5d66457...",
-                        "image_name": "us.icr.io/...",
-                        "container_type": "crio"
-                    },
-		    "x-oca-pod-ext": {
-                        "name": "example pod",
-                        "ip_refs": ["4"]
-                    }
-		}
+			"host_type": "APM Server",
+			"egress":{
+				"zone": "internal",
+				"interface": {
+					"alias": "inside",
+					"id": "10",
+					"name", "eth0"
+				}
+			},
+			"extensions": {
+				"x-oca-container-ext": {
+							"name": "example container",
+							"id”: “bf032feb4117",
+							"image_id": "92b1b5d66457...",
+							"image_name": "us.icr.io/...",
+							"container_type": "crio"
+						},
+				"x-oca-pod-ext": {
+							"name": "example pod",
+							"ip_refs": ["4"]
+						}
+			}
 	    },
 	    "2":
 	    {

--- a/2.0/x-oca-geo.md
+++ b/2.0/x-oca-geo.md
@@ -1,0 +1,42 @@
+## x-oca-geo object
+The `x-oca-geo` object describes a specific location related to an event and its properties. 
+It can be referenced to describe the geolocation information derived from techniques such as Geo IP, IP Location etc or user-supplied.
+
+Please note that this object mimics the attributes of the [Location SDO](https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html#_th8nitr8jb4k)
+
+| property name | type | description |
+|--|--|--|
+| type | `string` | x-oca-geo |
+| extensions | `dictionary` | Specifies any extensions of the object, as a dictionary. |
+| city_name | `string` | The city that this geolocation describes. |
+| continent_name |`string`| Specifies the name of the continent.  |
+| country_iso_code |`string`| Specifies the ISO code of the country.  |
+| country_name |`string`| Specifies the name of the country.|
+| location |`dictionary`| Specifies the longitude and latitude of the location. Each dictionary key SHOULD come from the location coordinates vocabulary. |
+| name |`string`| Specifies a user-defined description of the location. This is not typically used in automated geolocation. |
+| region_iso_code |`string`| Specifies the region ISO code. |
+| region_name |`string`| Specifies the region name. |
+| time_zone |`string`| Specifies the time zone of the geolocation such as an IANA time zone name |
+
+### Location coordinates vocabulary
+| value | type | description |
+|--|--|--|
+| lon | `double` | Specifies the longitude of the location. |
+| lat | `double` | Specifies the latitude of the location. |
+
+### Example
+
+    {
+	    "0":
+	    {
+	        "type": "x-oca-geo",
+	        "name": "Dallas-1",
+			"time_zone": "America/Chicago",
+			"country_iso_code": "US",
+			"country_name": "United States of America",
+			"location":
+				"lon": "-96.800496798",
+				"lat": "32.785663524"
+	    }
+    }
+


### PR DESCRIPTION
This PR addresses the following:

1. Add host interface attributes to `x-oca-asset`.
2. Add `x-oca-geo` object to capture geolocation attributes.
3. Update `x-ibm-finding` object with reference to `x-oca-geo`.