### PR TITLE
Rename attributes to avoid reserve keyword `id`

### DIFF
--- a/2.0/custom-user-account.md
+++ b/2.0/custom-user-account.md
@@ -12,7 +12,7 @@ Specifies custom atributes for the [`user-account`](https://docs.oasis-open.org/
 | value | type | description |
 |--|--|--|
 | domain | `string` | Specifies the name of the directory the group is a member of. e.g., an LDAP or Active Directory domain name|
-| id | `integer` | Specifies the unique identifier for the group on the system/platform |
+| gid | `integer` | Specifies the unique identifier for the group on the system/platform |
 | name | `string` | Specifies the name of the group |
 
 Example:
@@ -23,7 +23,7 @@ Example:
             "x_domain": "NT AUTHORITY",
             "user_id": "SYSTEM",
             "account_login": "SYSTEM",
-            "x_group.id": "515",
+            "x_group.gid": "515",
             "x_group.name": "Domain local group",
             "x_group.domain": "internal.company.com"
         }

--- a/2.0/x-oca-asset.md
+++ b/2.0/x-oca-asset.md
@@ -31,7 +31,7 @@ The container asset extension represents a container.
 |--|--|--|
 | type | `string` | x-oca-container-ext |
 | name | `string` | container name |
-| id | `string` | container id |
+| container_id | `string` | container id |
 | image_name | `string` | container image name |
 | image_id | `string` | container image id |
 | container_type | `container_type_ov` | container type | 
@@ -76,7 +76,7 @@ The pod asset extension represents an oc/k8s pod.
 | value | type | description |
 |--|--|--|
 | alias | `string` | Specifies the interface alias as reported by the system. |
-| id | `string` | Specifies the interface ID. |
+| interface_id | `string` | Specifies the interface ID. |
 | name | `string` | Specifies the interface name as reported by the system.|
 
 ### Example
@@ -101,7 +101,7 @@ The pod asset extension represents an oc/k8s pod.
 				"interfaces": [
 					{
 					"alias": "inside",
-					"id": "10",
+					"interface_id": "10",
 					"name", "eth0"
 					}
 				]
@@ -109,7 +109,7 @@ The pod asset extension represents an oc/k8s pod.
 			"extensions": {
 				"x-oca-container-ext": {
 							"name": "example container",
-							"id”: “bf032feb4117",
+							"container_id”: “bf032feb4117",
 							"image_id": "92b1b5d66457...",
 							"image_name": "us.icr.io/...",
 							"container_type": "crio"


### PR DESCRIPTION
Rename attributes to avoid reserve keyword `id` in `custom-user-account` and `x-oca-asset` objects.