### PR TITLE
Fix Naming for IOB Schemas

### DIFF
--- a/2.x/SDO/extension_schema/x-oca-behavior.json
+++ b/2.x/SDO/extension_schema/x-oca-behavior.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/opencybersecurityalliance/oca-iob/main/apl_reference_implementation_bundle/revision_2/schemas/sdos/behavior.json",
+  "$id": "https://raw.githubusercontent.com/opencybersecurityalliance/stix-extensions/main/2.x/SDO/extension_schema/x-oca-behavior.json",
   "$schema": "http://json-schema.org/draft/2020-12/schema#",
   "title": "x-oca-behavior",
   "description": "Behavior objects define adversary behaviors associated with higher level MITRE ATT&CK tactics and techniques. The Attack Pattern SDO may have multiple behaviors associated with it. For example, a spearphishing attack may employ multiple behaviors (usage of email attachments, process modifying a registry key, network patterns, etc.).",

--- a/2.x/SDO/extension_schema/x-oca-behavior.json
+++ b/2.x/SDO/extension_schema/x-oca-behavior.json
@@ -1,7 +1,7 @@
 {
   "$id": "https://raw.githubusercontent.com/opencybersecurityalliance/oca-iob/main/apl_reference_implementation_bundle/revision_2/schemas/sdos/behavior.json",
   "$schema": "http://json-schema.org/draft/2020-12/schema#",
-  "title": "behavior",
+  "title": "x-oca-behavior",
   "description": "Behavior objects define adversary behaviors associated with higher level MITRE ATT&CK tactics and techniques. The Attack Pattern SDO may have multiple behaviors associated with it. For example, a spearphishing attack may employ multiple behaviors (usage of email attachments, process modifying a registry key, network patterns, etc.).",
   "type": "object",
   "allOf": [

--- a/2.x/SDO/extension_schema/x-oca-coa-playbook-ext.json
+++ b/2.x/SDO/extension_schema/x-oca-coa-playbook-ext.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/opencybersecurityalliance/stix-extensions/main/playbook/schemas/x-oca-coa-playbook-ext.json",
+  "$id": "https://raw.githubusercontent.com/opencybersecurityalliance/stix-extensions/main/2.x/SDO/extension_schema/x-oca-coa-playbook-ext.json",
   "$schema": "http://json-schema.org/draft/2020-12/schema#",
   "title": "x-oca-coa-playbook-ext",
   "description": "A property extension for the Course of Action SDO for sharing automated courses of action (i.e., orchestration workflows or playbooks).",

--- a/2.x/SDO/extension_schema/x-oca-detection.json
+++ b/2.x/SDO/extension_schema/x-oca-detection.json
@@ -1,7 +1,7 @@
 {
   "$id": "https://raw.githubusercontent.com/opencybersecurityalliance/oca-iob/main/apl_reference_implementation_bundle/revision_2/schemas/sdos/detection.json",
   "$schema": "http://json-schema.org/draft/2020-12/schema#",
-  "title": "detection",
+  "title": "x-oca-detection",
   "description": "Detections contain logic to detect an adversary behavior.",
   "type": "object",
   "allOf": [

--- a/2.x/SDO/extension_schema/x-oca-detection.json
+++ b/2.x/SDO/extension_schema/x-oca-detection.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/opencybersecurityalliance/oca-iob/main/apl_reference_implementation_bundle/revision_2/schemas/sdos/detection.json",
+  "$id": "https://raw.githubusercontent.com/opencybersecurityalliance/stix-extensions/main/2.x/SDO/extension_schema/x-oca-detection.json",
   "$schema": "http://json-schema.org/draft/2020-12/schema#",
   "title": "x-oca-detection",
   "description": "Detections contain logic to detect an adversary behavior.",

--- a/2.x/SDO/extension_schema/x-oca-detector.json
+++ b/2.x/SDO/extension_schema/x-oca-detector.json
@@ -1,7 +1,7 @@
 {
   "$id": "https://raw.githubusercontent.com/opencybersecurityalliance/oca-iob/main/apl_reference_implementation_bundle/revision_2/schemas/sdos/detector.json",
   "$schema": "http://json-schema.org/draft/2020-12/schema#",
-  "title": "detector",
+  "title": "x-oca-detector",
   "description": "Detector objects define tools, software, products, etc. that are capable of performing detection. They should likely be related to one or more Detection obects.",
   "type": "object",
   "allOf": [

--- a/2.x/SDO/extension_schema/x-oca-detector.json
+++ b/2.x/SDO/extension_schema/x-oca-detector.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/opencybersecurityalliance/oca-iob/main/apl_reference_implementation_bundle/revision_2/schemas/sdos/detector.json",
+  "$id": "https://raw.githubusercontent.com/opencybersecurityalliance/stix-extensions/main/2.x/SDO/extension_schema/x-oca-detector.json",
   "$schema": "http://json-schema.org/draft/2020-12/schema#",
   "title": "x-oca-detector",
   "description": "Detector objects define tools, software, products, etc. that are capable of performing detection. They should likely be related to one or more Detection obects.",

--- a/2.x/SDO/extension_schema/x-oca-playbook.json
+++ b/2.x/SDO/extension_schema/x-oca-playbook.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/opencybersecurityalliance/stix-extensions/main/playbook/schemas/x-oca-playbook.json",
+  "$id": "https://raw.githubusercontent.com/opencybersecurityalliance/stix-extensions/main/2.x/SDO/extension_schema/x-oca-playbook.json",
   "$schema": "http://json-schema.org/draft/2020-12/schema#",
   "title": "x-oca-playbook",
   "description": "A Playbook object represents a structured process, such as an orchestration workflow, alongside associated metadata.",

--- a/2.x/SDO/extension_schema/x-oca-tool-hvt-ext.json
+++ b/2.x/SDO/extension_schema/x-oca-tool-hvt-ext.json
@@ -1,5 +1,5 @@
 {
-  "$id": "https://raw.githubusercontent.com/opencybersecurityalliance/stix-extensions/main/2.x/SDO/extension_schema/tool_hvt_ext.json",
+  "$id": "https://raw.githubusercontent.com/opencybersecurityalliance/stix-extensions/main/2.x/SDO/extension_schema/x-oca-tool-hvt-ext.json",
   "$schema": "http://json-schema.org/draft/2020-12/schema#",
   "title": "x-oca-tool-hvt-ext",
   "description": "Tools are legitimate software that can be used by threat actors to perform attacks.",

--- a/2.x/SDO/extension_schema/x-oca-tool-hvt-ext.json
+++ b/2.x/SDO/extension_schema/x-oca-tool-hvt-ext.json
@@ -1,7 +1,7 @@
 {
   "$id": "https://raw.githubusercontent.com/opencybersecurityalliance/stix-extensions/main/2.x/SDO/extension_schema/tool_hvt_ext.json",
   "$schema": "http://json-schema.org/draft/2020-12/schema#",
-  "title": "x-oca-tool-hvt-ext.json",
+  "title": "x-oca-tool-hvt-ext",
   "description": "Tools are legitimate software that can be used by threat actors to perform attacks.",
   "type": "object",
   "allOf": [

--- a/2.x/SDO/x-oca-tool-hvt-ext.md
+++ b/2.x/SDO/x-oca-tool-hvt-ext.md
@@ -1,4 +1,4 @@
-## High Value Target Tool extension
+## x-oca-tool-hvt-ext
 
 High Value Targets (HVTs) are applications, their underlying information
 systems, and data for which unauthorized access, use, disclosure,


### PR DESCRIPTION
Behavior, detection, detector schema titles updated to "x-oca-name" format.

HVT tool extension schema fixed title. Renamed and updated corresponding .md file.

Schema id URLs have been updated. This does not include SCO schemas.